### PR TITLE
Include README.md in package via a manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Without this, the following error occurs when installing the package:

```
Downloading/unpacking django-send-email
  Downloading django-send-email-0.1.0.tar.gz
  Running setup.py (path:/home/twidi/dev/envs/oshop/build/django-send-email/setup.py) egg_info for package django-send-email
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/home/twidi/dev/envs/oshop/build/django-send-email/setup.py", line 6, in <module>
        README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
    FileNotFoundError: [Errno 2] No such file or directory: '/home/twidi/dev/envs/oshop/build/django-send-email/README.md'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/home/twidi/dev/envs/oshop/build/django-send-email/setup.py", line 6, in <module>

    README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()

FileNotFoundError: [Errno 2] No such file or directory: '/home/twidi/dev/envs/oshop/build/django-send-email/README.md'
```
